### PR TITLE
增加对script标签type的判断

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,10 @@ function analyzeHtml(content, pathMap, usePlaceholder) {
         var result = null;
         //$1为script标签, $2为内嵌脚本内容, $3为link标签, $4为注释内容
         if ($1) {
+            var type = $1.match(/type=(".*?"|'.*?')/i);
+            type = type && type[1];
+
+            var noJs = type && type.indexOf('javascript') == -1;
             //如果标签设置了data-fixed则不会收集此资源
             if (/(\sdata-fixed\s*=\s*)('true'|"true")/ig.test($1)) {
                 return m;

--- a/index.js
+++ b/index.js
@@ -63,8 +63,12 @@ function analyzeHtml(content, pathMap, usePlaceholder) {
         var result = null;
         //$1为script标签, $2为内嵌脚本内容, $3为link标签, $4为注释内容
         if ($1) {
+            var type = $1.match(/type=(".*?"|'.*?')/i);
+            type = type && type[1];
+
+            var noJs = type && type.indexOf('javascript') == -1;
             //如果标签设置了data-fixed则不会收集此资源
-            if (/(\sdata-fixed\s*=\s*)('true'|"true")/ig.test($1)) {
+            if (/(\sdata-fixed\s*=\s*)('true'|"true")/ig.test($1) || noJs) {
                 return m;
             }
             var head = /(\sdata-position\s*=\s*)('head'|"head")/ig.test($1);


### PR DESCRIPTION
若script标签有type，则在type为text/javascript时才处理。防止script标签用作其他时产生问题。
